### PR TITLE
feat: Add multi-language detection and filter support [Closes #6]

### DIFF
--- a/backend/controllers/articleController.js
+++ b/backend/controllers/articleController.js
@@ -1,6 +1,26 @@
 const Article = require('../models/Article');
 const mongoose = require('mongoose');
 const axios = require('axios');
+const { franc } = require('franc-min');
+
+// Map franc 3-letter ISO 639-3 codes → 2-letter ISO 639-1 codes used by NewsAPI / UI
+const FRANC_TO_ISO2 = {
+  eng: 'en', hin: 'hi', tam: 'ta', ben: 'bn', mar: 'mr',
+  tel: 'te', kan: 'kn', mal: 'ml', pan: 'pa', urd: 'ur',
+  spa: 'es', fra: 'fr', deu: 'de', zho: 'zh', ara: 'ar',
+  jpn: 'ja', kor: 'ko', por: 'pt', rus: 'ru', ita: 'it',
+  nld: 'nl', pol: 'pl', swe: 'sv', nor: 'no', dan: 'da',
+};
+
+/**
+ * Detect the language of a piece of text.
+ * Returns a 2-letter ISO 639-1 code, or 'en' as fallback.
+ */
+const detectLanguage = (text) => {
+  if (!text || text.trim().length < 10) return 'en';
+  const iso3 = franc(text, { minLength: 10 });
+  return FRANC_TO_ISO2[iso3] || 'en';
+};
 
 // Helper function to check if MongoDB is connected
 const isMongoConnected = () => {
@@ -94,7 +114,7 @@ exports.fetchNews = async (req, res) => {
   try {
     // Check if we have API key
     if (!process.env.NEWSAPI_KEY) {
-      // Return sample data if no API key
+      // Return sample data (mix of languages for demo) if no API key
       const allSampleArticles = [
         {
           id: 1,
@@ -105,17 +125,19 @@ exports.fetchNews = async (req, res) => {
           publishedAt: "2024-01-24",
           politicalBias: "Moderate",
           emotionalBias: "Positive",
+          language: 'en',
           saved: false
         },
         {
           id: 2,
-          title: "Global Climate Summit Reaches Historic Agreement",
-          description: "In a landmark moment for global environmental policy, world leaders have come together at the Climate Summit to sign a historic agreement aimed at drastically reducing carbon emissions.",
+          title: "वैश्विक जलवायु शिखर सम्मेलन में ऐतिहासिक समझौता हुआ",
+          description: "विश्व के नेताओं ने जलवायु परिवर्तन से निपटने के लिए एक ऐतिहासिक समझौते पर हस्ताक्षर किए हैं जिससे कार्बन उत्सर्जन में भारी कमी आएगी।",
           urlToImage: "https://i.pinimg.com/736x/5b/a4/66/5ba46665fc9bdb09ff6546654cc75e4d.jpg",
           category: "Environment",
           publishedAt: "2024-01-23",
           politicalBias: "Low",
           emotionalBias: "Hopeful",
+          language: 'hi',
           saved: false
         },
         {
@@ -127,28 +149,31 @@ exports.fetchNews = async (req, res) => {
           publishedAt: "2024-01-22",
           politicalBias: "High",
           emotionalBias: "Optimistic",
+          language: 'en',
           saved: false
         },
         {
           id: 4,
-          title: "Breakthrough in Space Exploration Technology",
-          description: "A major advancement in space exploration technology is set to revolutionize future missions, with new innovations enhancing spacecraft efficiency and deep-space communication.",
+          title: "புதிய விண்வெளி ஆராய்ச்சி தொழில்நுட்பம் புரட்சி ஏற்படுத்துகிறது",
+          description: "விண்வெளி ஆராய்ச்சியில் புதிய கண்டுபிடிப்புகள் மனித இனத்தின் எதிர்காலத்தை மாற்றும் என்று விஞ்ஞானிகள் தெரிவித்தனர்.",
           urlToImage: "https://i.pinimg.com/1200x/de/35/3c/de353c9f646c31592a03faf7ef15065c.jpg",
           category: "Science",
           publishedAt: "2024-01-21",
           politicalBias: "Moderate",
           emotionalBias: "Exciting",
+          language: 'ta',
           saved: false
         },
         {
           id: 5,
-          title: "New Political Reforms Announced by Government",
-          description: "The government has announced comprehensive political reforms aimed at increasing transparency and public participation in the democratic process.",
+          title: "সরকার নতুন রাজনৈতিক সংস্কার ঘোষণা করেছে",
+          description: "সরকার স্বচ্ছতা বৃদ্ধি এবং গণতান্ত্রিক প্রক্রিয়ায় জনগণের অংশগ্রহণ বাড়াতে ব্যাপক রাজনৈতিক সংস্কারের ঘোষণা দিয়েছে।",
           urlToImage: "https://i.pinimg.com/1200x/9a/14/b8/9a14b84bb2cc2f5405f4c3676a77aec6.jpg",
           category: "Politics",
           publishedAt: "2024-01-20",
           politicalBias: "High",
           emotionalBias: "Neutral",
+          language: 'bn',
           saved: false
         },
         {
@@ -160,6 +185,31 @@ exports.fetchNews = async (req, res) => {
           publishedAt: "2024-01-19",
           politicalBias: "Low",
           emotionalBias: "Positive",
+          language: 'en',
+          saved: false
+        },
+        {
+          id: 7,
+          title: "मराठी उद्योग क्षेत्रात मोठी प्रगती",
+          description: "महाराष्ट्रातील उद्योग क्षेत्रात नव्या तंत्रज्ञानाचा वापर करून मोठ्या प्रमाणावर रोजगार निर्मिती होत आहे.",
+          urlToImage: "https://i.pinimg.com/1200x/38/d4/d7/38d4d70886c8a2dd73f3e5f1497c8f73.jpg",
+          category: "Business",
+          publishedAt: "2024-01-18",
+          politicalBias: "Low",
+          emotionalBias: "Positive",
+          language: 'mr',
+          saved: false
+        },
+        {
+          id: 8,
+          title: "తెలుగు రాష్ట్రంలో కొత్త సాంకేతిక విద్యా కేంద్రాలు",
+          description: "ఆంధ్రప్రదేశ్ మరియు తెలంగాణలో కొత్త సాంకేతిక విద్యా కేంద్రాలు ప్రారంభమవుతున్నాయి, ఇవి యువతకు ఉద్యోగావకాశాలు కల్పిస్తాయి.",
+          urlToImage: "https://i.pinimg.com/1200x/de/35/3c/de353c9f646c31592a03faf7ef15065c.jpg",
+          category: "Technology",
+          publishedAt: "2024-01-17",
+          politicalBias: "Low",
+          emotionalBias: "Hopeful",
+          language: 'te',
           saved: false
         }
       ];
@@ -180,7 +230,14 @@ exports.fetchNews = async (req, res) => {
         );
       }
 
-      // Analyze bias for each article (simulated AI analysis)
+      // Filter by language if provided (and not 'all')
+      if (language && language !== 'all') {
+        filteredArticles = filteredArticles.filter(article =>
+          article.language === language
+        );
+      }
+
+      // Analyze bias for each article
       const analyzedArticles = filteredArticles.map(article => {
         const biasAnalysis = analyzeBias(article.title, article.description);
         return {
@@ -201,12 +258,21 @@ exports.fetchNews = async (req, res) => {
     }
 
     // If we have API key, use real NewsAPI
+    // NewsAPI supports a limited set of language codes; pass through if valid
+    const newsApiLanguages = ['ar','de','en','es','fr','he','it','nl','no','pt','ru','sv','ud','zh'];
     const params = {
       apiKey: process.env.NEWSAPI_KEY,
-      country: 'us',
-      language: language || 'en',
       pageSize: pageSize
     };
+
+    // Only pass language to NewsAPI if it's a supported code, else fetch all and filter
+    if (language && language !== 'all' && newsApiLanguages.includes(language)) {
+      params.language = language;
+    } else if (!language || language === 'all') {
+      params.language = 'en';
+    }
+    // For Indian languages (hi, ta, bn, mr, te, kn, ml) — don't filter at API level,
+    // detect language locally and filter after fetch
 
     if (category && category !== 'all') {
       params.category = category;
@@ -220,16 +286,20 @@ exports.fetchNews = async (req, res) => {
     
     const newsArticles = response.data.articles || [];
     
-    // Transform the response and analyze bias for each article
-    const articles = newsArticles.map((article, index) => {
+    // Transform + detect language for each article
+    let articles = newsArticles.map((article, index) => {
       const biasAnalysis = analyzeBias(article.title, article.description);
+      const detectedLang = detectLanguage(`${article.title || ''} ${article.description || ''}`);
       return {
         id: index + 1,
         title: article.title,
         description: article.description,
         urlToImage: article.urlToImage,
+        url: article.url,
+        source: article.source?.name || '',
         category: category || 'General',
         publishedAt: article.publishedAt,
+        language: detectedLang,
         politicalBias: biasAnalysis.politicalBias,
         emotionalBias: biasAnalysis.emotionalBias,
         politicalBiasScore: biasAnalysis.politicalBiasScore,
@@ -238,9 +308,14 @@ exports.fetchNews = async (req, res) => {
       };
     });
 
+    // Post-fetch language filter for languages not natively supported by NewsAPI
+    if (language && language !== 'all') {
+      articles = articles.filter(a => a.language === language);
+    }
+
     res.json({
       articles: articles,
-      totalResults: response.data.totalResults,
+      totalResults: articles.length,
       status: response.data.status
     });
   } catch (error) {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "franc-min": "^6.2.0",
         "mongoose": "^8.16.4",
         "news-setu-root": "file:..",
         "openai": "^5.10.2",
@@ -187,6 +188,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/combined-stream": {
@@ -518,6 +529,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/franc-min": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/franc-min/-/franc-min-6.2.0.tgz",
+      "integrity": "sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==",
+      "license": "MIT",
+      "dependencies": {
+        "trigram-utils": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/fresh": {
@@ -877,6 +901,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/n-gram": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1395,6 +1429,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/trigram-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+      "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "collapse-white-space": "^2.0.0",
+        "n-gram": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/type-is": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "franc-min": "^6.2.0",
     "mongoose": "^8.16.4",
     "news-setu-root": "file:..",
     "openai": "^5.10.2",

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -2,7 +2,18 @@ import React, { useState, useEffect } from "react";
 import { Clock, Calendar, Languages, Volume2, VolumeX, Play, Pause } from "lucide-react";
 import { useTheme } from "./context/ThemeContext.jsx";
 import apiService from "./services/api.js";
+import LanguageFilter, { LANGUAGES } from "./components/LanguageFilter.jsx";
 import './styles/Landingpage.css';
+
+// Languages that use Indic scripts — get an orange badge variant
+const INDIAN_LANG_CODES = new Set(['hi', 'ta', 'bn', 'mr', 'te', 'kn', 'ml', 'pa', 'ur']);
+
+/** Return the short display label for a language code (e.g. 'hi' → 'HI · Hindi') */
+const getLangLabel = (code) => {
+  if (!code) return null;
+  const found = LANGUAGES.find((l) => l.code === code);
+  return found ? `${found.flag} ${code.toUpperCase()}` : code.toUpperCase();
+};
 
 const LandingPageData = [
   {
@@ -165,6 +176,10 @@ const LandingPage = ({ onPageChange }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [selectedBias, setSelectedBias] = useState("all");
+  // Language filter: persisted in localStorage via LanguageFilter component
+  const [selectedFilterLanguage, setSelectedFilterLanguage] = useState(
+    () => localStorage.getItem('newssetu_language_filter') || 'all'
+  );
   const [articles, setArticles] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -175,15 +190,20 @@ const LandingPage = ({ onPageChange }) => {
   const [ttsStates, setTtsStates] = useState({});
   const [speechUtterance, setSpeechUtterance] = useState(null);
 
-  // Fetch news on component mount and when search/category changes
+  // Fetch news on component mount and when search/category/language changes
   useEffect(() => {
     fetchNews();
-  }, [searchQuery, selectedCategory]);
+  }, [searchQuery, selectedCategory, selectedFilterLanguage]);
 
   const fetchNews = async () => {
     try {
       setLoading(true);
-      const response = await apiService.fetchNews(searchQuery, selectedCategory);
+      // Pass selectedFilterLanguage as 3rd arg; 'all' means no language filter
+      const response = await apiService.fetchNews(
+        searchQuery,
+        selectedCategory,
+        selectedFilterLanguage !== 'all' ? selectedFilterLanguage : ''
+      );
       // Map urlToImage to image for consistency
       const mappedArticles = (response.articles || []).map(article => ({
         ...article,
@@ -335,6 +355,13 @@ const LandingPage = ({ onPageChange }) => {
             <option value="high">High</option>
           </select>
 
+          {/* Task #3 & #4 — Language filter dropdown */}
+          <span className="dropdown-label">Language: </span>
+          <LanguageFilter
+            value={selectedFilterLanguage}
+            onChange={setSelectedFilterLanguage}
+          />
+
           <span className="dropdown-label">Translate to: </span>
           <select value={selectedLanguage} onChange={(e) => setSelectedLanguage(e.target.value)}>
             <option value="es">Spanish</option>
@@ -373,7 +400,16 @@ const LandingPage = ({ onPageChange }) => {
                 <div className="meta">
                   <span className="category">{article.category}</span>
                   <span><Clock size={10} /> {article.readTime}</span>
-                  <span><Calendar size={10} /> {article.publishDate}</span>
+                  <span><Calendar size={10} /> {article.publishDate || article.publishedAt?.slice(0, 10)}</span>
+                  {/* Task #5 — Language badge */}
+                  {article.language && (
+                    <span
+                      className={`lang-badge${INDIAN_LANG_CODES.has(article.language) ? ' lang-indian' : ''}`}
+                      title={`Article language: ${article.language}`}
+                    >
+                      {getLangLabel(article.language)}
+                    </span>
+                  )}
                 </div>
                 <h3 className="title">
                   {translations[article.id] ? translations[article.id].title : article.title}

--- a/frontend/src/components/LanguageFilter.css
+++ b/frontend/src/components/LanguageFilter.css
@@ -1,0 +1,44 @@
+/* LanguageFilter Component Styles */
+
+.language-filter-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  position: relative;
+}
+
+.language-filter-flag {
+  font-size: 1.1rem;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
+.language-filter-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-color: var(--select-bg, rgba(255, 255, 255, 0.08));
+  color: var(--select-color, inherit);
+  border: 1px solid var(--select-border, rgba(255, 255, 255, 0.18));
+  border-radius: 8px;
+  padding: 6px 28px 6px 10px;
+  font-size: 0.875rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23aaa' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  min-width: 140px;
+}
+
+.language-filter-select:hover {
+  border-color: var(--select-hover-border, rgba(255, 255, 255, 0.4));
+  background-color: var(--select-hover-bg, rgba(255, 255, 255, 0.14));
+}
+
+.language-filter-select:focus {
+  outline: none;
+  border-color: var(--accent, #6c63ff);
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+}

--- a/frontend/src/components/LanguageFilter.jsx
+++ b/frontend/src/components/LanguageFilter.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import './LanguageFilter.css';
+
+const LANGUAGES = [
+  { code: 'all', label: 'All Languages', flag: '🌐' },
+  // Indian Languages
+  { code: 'en', label: 'English', flag: '🇬🇧' },
+  { code: 'hi', label: 'Hindi', flag: '🇮🇳' },
+  { code: 'ta', label: 'Tamil', flag: '🇮🇳' },
+  { code: 'bn', label: 'Bengali', flag: '🇮🇳' },
+  { code: 'mr', label: 'Marathi', flag: '🇮🇳' },
+  { code: 'te', label: 'Telugu', flag: '🇮🇳' },
+  { code: 'kn', label: 'Kannada', flag: '🇮🇳' },
+  { code: 'ml', label: 'Malayalam', flag: '🇮🇳' },
+  { code: 'pa', label: 'Punjabi', flag: '🇮🇳' },
+  { code: 'ur', label: 'Urdu', flag: '🇵🇰' },
+  // International
+  { code: 'es', label: 'Spanish', flag: '🇪🇸' },
+  { code: 'fr', label: 'French', flag: '🇫🇷' },
+  { code: 'de', label: 'German', flag: '🇩🇪' },
+  { code: 'zh', label: 'Chinese', flag: '🇨🇳' },
+  { code: 'ar', label: 'Arabic', flag: '🇸🇦' },
+  { code: 'ja', label: 'Japanese', flag: '🇯🇵' },
+  { code: 'ko', label: 'Korean', flag: '🇰🇷' },
+  { code: 'pt', label: 'Portuguese', flag: '🇧🇷' },
+  { code: 'ru', label: 'Russian', flag: '🇷🇺' },
+];
+
+const STORAGE_KEY = 'newssetu_language_filter';
+
+const LanguageFilter = ({ value, onChange }) => {
+  // Restore from localStorage on first mount
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved && saved !== value) {
+      onChange(saved);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChange = (e) => {
+    const lang = e.target.value;
+    localStorage.setItem(STORAGE_KEY, lang);
+    onChange(lang);
+  };
+
+  const selectedLang = LANGUAGES.find((l) => l.code === value) || LANGUAGES[0];
+
+  return (
+    <div className="language-filter-wrapper">
+      <span className="language-filter-flag">{selectedLang.flag}</span>
+      <select
+        id="language-filter-select"
+        className="language-filter-select"
+        value={value}
+        onChange={handleChange}
+        aria-label="Filter articles by language"
+      >
+        {LANGUAGES.map((lang) => (
+          <option key={lang.code} value={lang.code}>
+            {lang.flag} {lang.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export { LANGUAGES };
+export default LanguageFilter;

--- a/frontend/src/styles/Landingpage.css
+++ b/frontend/src/styles/Landingpage.css
@@ -425,6 +425,42 @@ select {
   background-color: #6c757d;
 }
 
+/* Language badge on article cards */
+.lang-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 7px;
+  border-radius: 4px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background-color: rgba(108, 99, 255, 0.15);
+  color: #6c63ff;
+  border: 1px solid rgba(108, 99, 255, 0.3);
+  white-space: nowrap;
+}
+
+[data-theme="dark"] .lang-badge {
+  background-color: rgba(108, 99, 255, 0.2);
+  color: #a89fff;
+  border-color: rgba(108, 99, 255, 0.4);
+}
+
+/* Indian language badge variant */
+.lang-badge.lang-indian {
+  background-color: rgba(255, 153, 51, 0.15);
+  color: #cc6600;
+  border-color: rgba(255, 153, 51, 0.35);
+}
+
+[data-theme="dark"] .lang-badge.lang-indian {
+  background-color: rgba(255, 153, 51, 0.2);
+  color: #ffaa44;
+  border-color: rgba(255, 153, 51, 0.45);
+}
+
 .footer {
   margin-top: 60px;
   padding: 20px;


### PR DESCRIPTION
## Summary

Implements multi-language news support as described in #6. Users can now filter 
the news grid by language (English, Hindi, Tamil, Bengali, Marathi, Telugu, and more), 
and each article card displays a language badge showing what language it's written in.

## Changes

### Backend
- Installed `franc-min` for server-side language detection
- Added `detectLanguage()` helper with ISO 639-3 → ISO 639-1 code mapping
- `GET /api/articles/news` now accepts `?language=` query param and filters results
- Sample data enriched with articles in Hindi, Tamil, Bengali, Marathi, and Telugu
- For Indian languages not supported by NewsAPI, detection runs locally post-fetch

### Frontend
- **New:** `LanguageFilter.jsx` — dropdown with 19 languages (all major Indian + international)
- Language selection persists across page refreshes via `localStorage`
- `fetchNews()` re-fires automatically when language filter changes
- Each article card shows a language badge (`🇬🇧 EN`, `🇮🇳 HI`, etc.)
- Indian language badges use a distinct orange color to distinguish from international ones

## How to Test

1. Open the news feed
2. Select **"🇮🇳 Hindi"** from the Language dropdown → only Hindi articles appear
3. Select **"🌐 All Languages"** → all articles return
4. Refresh the page → language selection is remembered
5. Each article card shows a small language badge in the meta row

## Screenshots

> _(attach screenshot of the Language dropdown and article badges here)_

## Related

Closes #6
