### PR TITLE
 Perfectly align center navigation links in NavbarInitial Commit

### DIFF
--- a/frontend/src/styles/Navbar.css
+++ b/frontend/src/styles/Navbar.css
@@ -32,6 +32,9 @@
 .navbar .nav-links-desktop {
   display: flex;
   gap: 20px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .navbar .nav-links-desktop a {


### PR DESCRIPTION
Updated the CSS for the desktop navigation links (.nav-links-desktop) to use absolute positioning.
 Previously, using justify-content: space-between on the main navbar container caused the center links to be slightly misaligned because the logo on the left and the buttons on the right had different widths.
By applying position: absolute, left: 50%, and transform: translateX(-50%), the "Home" and "About" links are now taken out of the flex document flow and perfectly centered relative to the entire screen width, resulting in a perfectly balanced UI.